### PR TITLE
chore(config): ignore .beads in linters and formatters

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -26,7 +26,7 @@ Max 0 ESLint warnings enforced.
 
 - `node_modules`, `dist`, `build`, `out`
 - `.nitro`, `.output`, `.tanstack`, `.vinxi`, `.wrangler`
-- `.turbo`
+- `.turbo`, `.beads`
 - `coverage`, `playwright-report`, `test-results`, `storybook-static`
 - `**/*.gen.ts` - Generated files
 - `**/drizzle.config.ts` - Drizzle config

--- a/.prettierignore
+++ b/.prettierignore
@@ -21,6 +21,9 @@ out
 # Framework - Turbo
 .turbo
 
+# Issue tracking
+.beads
+
 # Testing
 coverage
 

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -40,6 +40,9 @@ export default defineConfig(
     // Storybook
     '**/storybook-static',
 
+    // Issue tracking
+    '**/.beads',
+
     // Generated files
     '**/*.gen.ts',
   ]),


### PR DESCRIPTION
## Summary
- Add `.beads` to `.prettierignore` to prevent formatting changes
- Add `**/.beads` to ESLint's `globalIgnores` 
- Update documentation in `.claude/rules/code-style.md`

Prevents linters/formatters from modifying beads metadata files, avoiding issues like trailing newline changes.

## Test plan
- [x] All lint checks pass
- [x] Verified with `bd doctor`